### PR TITLE
Feat/database

### DIFF
--- a/app/enums/__init__.py
+++ b/app/enums/__init__.py
@@ -1,0 +1,5 @@
+"""Enums package"""
+
+from .group_roles import GroupRole
+
+__all__ = ["GroupRole"]

--- a/app/enums/group_roles.py
+++ b/app/enums/group_roles.py
@@ -1,0 +1,11 @@
+"""Group role enums"""
+
+from enum import Enum
+
+
+class GroupRole(str, Enum):
+    """Group member role enum"""
+
+    ADMIN = "admin"
+    MANAGER = "manager"
+    MEMBER = "member"

--- a/app/enums/group_roles.py
+++ b/app/enums/group_roles.py
@@ -6,6 +6,6 @@ from enum import Enum
 class GroupRole(str, Enum):
     """Group member role enum"""
 
-    ADMIN = "admin"
-    MANAGER = "manager"
-    MEMBER = "member"
+    ADMIN = "ADMIN"
+    MANAGER = "MANAGER"
+    MEMBER = "MEMBER"

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,29 @@
+"""Models package initialization"""
+
+from .challenge_winners import ChallengeWinnerModel
+from .challenges import ChallengeModel
+from .comments import CommentModel
+from .group_members import GroupMembersModel
+from .groups import GroupModel
+from .invitations import InvitationModel
+from .likes import LikeModel
+from .point_transactions import PointTransactionModel
+from .posts import PostModel
+from .refresh_tokens import RefreshTokenModel
+from .user_points import UserPointsModel
+from .users import UserModel
+
+__all__ = [
+    "UserModel",
+    "GroupModel",
+    "GroupMembersModel",
+    "PostModel",
+    "CommentModel",
+    "LikeModel",
+    "InvitationModel",
+    "RefreshTokenModel",
+    "ChallengeModel",
+    "ChallengeWinnerModel",
+    "UserPointsModel",
+    "PointTransactionModel",
+]

--- a/app/models/challenge_winners.py
+++ b/app/models/challenge_winners.py
@@ -1,0 +1,62 @@
+"""challenge winners model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class ChallengeWinnerModel(Base):
+    """database challenge winners Model(Entity)"""
+
+    __tablename__ = "challenge_winners"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    challenge_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("challenges.id"),
+        nullable=False,
+        index=True,
+    )
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("posts.id"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    rank: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+
+    # Relationships
+    challenge = relationship(
+        argument="ChallengeModel",
+        back_populates="winners",
+    )
+    post = relationship(
+        argument="PostModel",
+        back_populates="challenge_winner",
+    )
+    user = relationship(
+        argument="UserModel",
+        back_populates="challenge_winners",
+    )

--- a/app/models/challenges.py
+++ b/app/models/challenges.py
@@ -1,0 +1,67 @@
+"""challenges model(entity)"""
+
+import uuid
+
+from sqlalchemy import Enum, String, TIMESTAMP, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class ChallengeModel(Base):
+    """database challenges Model(Entity)"""
+
+    __tablename__ = "challenges"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(
+        String(length=255),
+        nullable=False,
+    )
+    description: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    start_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+    )
+    end_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+    )
+    status: Mapped[str] = mapped_column(
+        Enum(
+            "UPCOMING",
+            "ACTIVE",
+            "COMPLETED",
+            name="challenge_status",
+        ),
+        nullable=False,
+        default="UPCOMING",
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    posts = relationship(
+        argument="PostModel",
+        back_populates="challenge",
+    )
+    winners = relationship(
+        argument="ChallengeWinnerModel",
+        back_populates="challenge",
+    )

--- a/app/models/comments.py
+++ b/app/models/comments.py
@@ -1,0 +1,51 @@
+"""comments model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, TIMESTAMP, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class CommentModel(Base):
+    """database comments Model(Entity)"""
+
+    __tablename__ = "comments"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("posts.id"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    content: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    user = relationship(argument="UserModel", back_populates="comments")
+    post = relationship(argument="PostModel", back_populates="comments")

--- a/app/models/group_members.py
+++ b/app/models/group_members.py
@@ -27,7 +27,7 @@ class GroupMembersModel(Base):
         index=True,
     )
     role: Mapped[str] = mapped_column(
-        Enum("ADMIN", "MEMBER", name="group_role"),
+        Enum("ADMIN", "MEMBER", "MANAGER", name="group_role"),
         nullable=False,
         default="MEMBER",
     )

--- a/app/models/group_members.py
+++ b/app/models/group_members.py
@@ -1,0 +1,37 @@
+"""group members model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, String, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class GroupMembersModel(Base):
+    """database group members Model(Entity)"""
+
+    __tablename__ = "group_members"
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        primary_key=True,
+        index=True,
+    )
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id"),
+        primary_key=True,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(
+        String(length=50),
+        nullable=False,
+        default="member",
+    )
+    joined_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )

--- a/app/models/group_members.py
+++ b/app/models/group_members.py
@@ -2,11 +2,13 @@
 
 import uuid
 
-from sqlalchemy import ForeignKey, String, TIMESTAMP, func
+from sqlalchemy import Enum as SQLEnum
+from sqlalchemy import ForeignKey, TIMESTAMP, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database.database import Base
+from app.enums import GroupRole
 
 
 # pylint:disable=not-callable, too-few-public-methods
@@ -26,10 +28,10 @@ class GroupMembersModel(Base):
         primary_key=True,
         index=True,
     )
-    role: Mapped[str] = mapped_column(
-        String(length=50),
+    role: Mapped[GroupRole] = mapped_column(
+        SQLEnum(GroupRole),
         nullable=False,
-        default="member",
+        default=GroupRole.MEMBER,
     )
     joined_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),

--- a/app/models/group_members.py
+++ b/app/models/group_members.py
@@ -2,9 +2,9 @@
 
 import uuid
 
-from sqlalchemy import ForeignKey, String, TIMESTAMP, func
+from sqlalchemy import Enum, ForeignKey, TIMESTAMP, func
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database.database import Base
 
@@ -27,11 +27,21 @@ class GroupMembersModel(Base):
         index=True,
     )
     role: Mapped[str] = mapped_column(
-        String(length=50),
+        Enum("ADMIN", "MEMBER", name="group_role"),
         nullable=False,
-        default="member",
+        default="MEMBER",
     )
     joined_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
+    )
+
+    # Relationships
+    user = relationship(
+        argument="UserModel",
+        back_populates="group_memberships",
+    )
+    group = relationship(
+        argument="GroupModel",
+        back_populates="members",
     )

--- a/app/models/groups.py
+++ b/app/models/groups.py
@@ -3,7 +3,7 @@
 # pylint:disable=not-callable, too-few-public-methods
 import uuid
 
-from sqlalchemy import ForeignKey, String, TIMESTAMP, Text, func
+from sqlalchemy import Enum, ForeignKey, String, TIMESTAMP, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -37,6 +37,11 @@ class GroupModel(Base):
         nullable=True,
         default=None,
     )
+    type: Mapped[str] = mapped_column(
+        Enum("PUBLIC", "PRIVATE", name="group_type"),
+        nullable=False,
+        default="PUBLIC",
+    )
     created_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
@@ -51,12 +56,17 @@ class GroupModel(Base):
     creator = relationship(
         argument="UserModel",
         back_populates="created_groups",
+        foreign_keys=[creator_id],
     )
     posts = relationship(
         argument="PostModel",
         back_populates="group",
     )
-    invitation_codes = relationship(
-        argument="InvitationCode",
+    invitations = relationship(
+        argument="InvitationModel",
+        back_populates="group",
+    )
+    members = relationship(
+        argument="GroupMembersModel",
         back_populates="group",
     )

--- a/app/models/groups.py
+++ b/app/models/groups.py
@@ -1,0 +1,62 @@
+"""groups model(entity)"""
+
+# pylint:disable=not-callable, too-few-public-methods
+import uuid
+
+from sqlalchemy import ForeignKey, String, TIMESTAMP, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+class GroupModel(Base):
+    """database groups Model(Entity)"""
+
+    __tablename__ = "groups"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(column="users.id"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(
+        String(length=100),
+        unique=True,
+        index=True,
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    creator = relationship(
+        argument="UserModel",
+        back_populates="created_groups",
+    )
+    posts = relationship(
+        argument="PostModel",
+        back_populates="group",
+    )
+    invitation_codes = relationship(
+        argument="InvitationCode",
+        back_populates="group",
+    )

--- a/app/models/invitation_codes.py
+++ b/app/models/invitation_codes.py
@@ -1,0 +1,68 @@
+"""invitation codes model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, INT, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class InvitationCode(Base):
+    """database invitation codes Model(Entity)"""
+
+    __tablename__ = "invitation_codes"
+    code: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id"),
+        nullable=False,
+        index=True,
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    expired_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    max_uses: Mapped[int] = mapped_column(
+        INT,
+        nullable=False,
+        default=3,
+    )
+    current_uses: Mapped[int] = mapped_column(
+        INT,
+        nullable=False,
+        default=0,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    group = relationship(
+        argument="GroupModel",
+        back_populates="invitation_codes",
+    )
+    creator = relationship(
+        argument="UserModel",
+        back_populates="created_invitation_codes",
+    )

--- a/app/models/invitation_codes.py
+++ b/app/models/invitation_codes.py
@@ -1,8 +1,8 @@
-"""invitation codes model(entity)"""
+"""invitations model(entity)"""
 
 import uuid
 
-from sqlalchemy import ForeignKey, INT, TIMESTAMP, func
+from sqlalchemy import ForeignKey, Integer, String, TIMESTAMP, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -10,14 +10,13 @@ from app.database.database import Base
 
 
 # pylint:disable=not-callable, too-few-public-methods
-class InvitationCode(Base):
-    """database invitation codes Model(Entity)"""
+class InvitationModel(Base):
+    """database invitations Model(Entity)"""
 
-    __tablename__ = "invitation_codes"
-    code: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+    __tablename__ = "invitations"
+    code: Mapped[str] = mapped_column(
+        String(length=255),
         primary_key=True,
-        default=uuid.uuid4,
         index=True,
     )
     group_id: Mapped[uuid.UUID] = mapped_column(
@@ -32,18 +31,16 @@ class InvitationCode(Base):
         nullable=False,
         index=True,
     )
-    expired_at: Mapped[TIMESTAMP] = mapped_column(
+    expires_at: Mapped[TIMESTAMP | None] = mapped_column(
         TIMESTAMP(timezone=True),
-        nullable=False,
-        index=True,
+        nullable=True,
     )
-    max_uses: Mapped[int] = mapped_column(
-        INT,
-        nullable=False,
-        default=3,
+    max_uses: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
     )
-    current_uses: Mapped[int] = mapped_column(
-        INT,
+    use_count: Mapped[int] = mapped_column(
+        Integer,
         nullable=False,
         default=0,
     )
@@ -51,16 +48,11 @@ class InvitationCode(Base):
         TIMESTAMP(timezone=True),
         server_default=func.now(),
     )
-    updated_at: Mapped[TIMESTAMP] = mapped_column(
-        TIMESTAMP(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-    )
 
     # Relationships
     group = relationship(
         argument="GroupModel",
-        back_populates="invitation_codes",
+        back_populates="invitations",
     )
     creator = relationship(
         argument="UserModel",

--- a/app/models/invitations.py
+++ b/app/models/invitations.py
@@ -1,0 +1,60 @@
+"""invitations model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, String, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class InvitationModel(Base):
+    """database invitations Model(Entity)"""
+
+    __tablename__ = "invitations"
+    code: Mapped[str] = mapped_column(
+        String(length=255),
+        primary_key=True,
+        index=True,
+    )
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id"),
+        nullable=False,
+        index=True,
+    )
+    creator_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    expires_at: Mapped[TIMESTAMP | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )
+    max_uses: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+    use_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+
+    # Relationships
+    group = relationship(
+        argument="GroupModel",
+        back_populates="invitations",
+    )
+    creator = relationship(
+        argument="UserModel",
+        back_populates="created_invitation_codes",
+    )

--- a/app/models/likes.py
+++ b/app/models/likes.py
@@ -1,0 +1,42 @@
+"""likes model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class LikeModel(Base):
+    """database likes Model(Entity)"""
+
+    __tablename__ = "likes"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    post_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("posts.id"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+
+    # Relationships
+    user = relationship(argument="UserModel", back_populates="likes")
+    post = relationship(argument="PostModel", back_populates="likes")

--- a/app/models/likes.py
+++ b/app/models/likes.py
@@ -14,22 +14,16 @@ class LikeModel(Base):
     """database likes Model(Entity)"""
 
     __tablename__ = "likes"
-    id: Mapped[uuid.UUID] = mapped_column(
+    user_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
+        ForeignKey("users.id"),
         primary_key=True,
-        default=uuid.uuid4,
         index=True,
     )
     post_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("posts.id"),
-        nullable=False,
-        index=True,
-    )
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
-        ForeignKey("users.id"),
-        nullable=False,
+        primary_key=True,
         index=True,
     )
     created_at: Mapped[TIMESTAMP] = mapped_column(

--- a/app/models/point_transactions.py
+++ b/app/models/point_transactions.py
@@ -1,0 +1,50 @@
+"""point transactions model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, String, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class PointTransactionModel(Base):
+    """database point transactions Model(Entity)"""
+
+    __tablename__ = "point_transactions"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    points_change: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+    )
+    reason: Mapped[str] = mapped_column(
+        String(length=255),
+        nullable=False,
+    )
+    related_entity_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        nullable=True,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+
+    # Relationships
+    user = relationship(
+        argument="UserModel",
+        back_populates="point_transactions",
+    )

--- a/app/models/posts.py
+++ b/app/models/posts.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlalchemy import ForeignKey, String, TIMESTAMP, Text, func
+from sqlalchemy import ForeignKey, Integer, String, TIMESTAMP, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -32,12 +32,18 @@ class PostModel(Base):
         nullable=False,
         index=True,
     )
-    title: Mapped[str] = mapped_column(
-        String(length=255),
-        nullable=False,
+    challenge_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("challenges.id"),
+        nullable=True,
+        index=True,
     )
     content: Mapped[str] = mapped_column(
         Text,
+        nullable=False,
+    )
+    image_url: Mapped[str] = mapped_column(
+        String(length=2048),
         nullable=False,
     )
     created_at: Mapped[TIMESTAMP] = mapped_column(
@@ -55,3 +61,7 @@ class PostModel(Base):
     group = relationship(argument="GroupModel", back_populates="posts")
     likes = relationship(argument="LikeModel", back_populates="post")
     comments = relationship(argument="CommentModel", back_populates="post")
+    challenge = relationship(argument="ChallengeModel", back_populates="posts")
+    challenge_winner = relationship(
+        argument="ChallengeWinnerModel", back_populates="post", uselist=False
+    )

--- a/app/models/potsts.py
+++ b/app/models/potsts.py
@@ -1,0 +1,57 @@
+"""posts model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, String, TIMESTAMP, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class PostModel(Base):
+    """database posts Model(Entity)"""
+
+    __tablename__ = "posts"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(
+        String(length=255),
+        nullable=False,
+    )
+    content: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    user = relationship(argument="UserModel", back_populates="posts")
+    group = relationship(argument="GroupModel", back_populates="posts")
+    likes = relationship(argument="LikeModel", back_populates="post")
+    comments = relationship(argument="CommentModel", back_populates="post")

--- a/app/models/refresh_tokens.py
+++ b/app/models/refresh_tokens.py
@@ -1,0 +1,66 @@
+"""refresh tokens model(entity)"""
+
+import uuid
+
+from sqlalchemy import Boolean, ForeignKey, String, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class RefreshTokenModel(Base):
+    """database refresh tokens Model(Entity)"""
+
+    __tablename__ = "refresh_tokens"
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    token: Mapped[str] = mapped_column(
+        String(length=255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        nullable=False,
+        index=True,
+    )
+    expires_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+    )
+    is_revoked: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+    device_info: Mapped[str | None] = mapped_column(
+        String(length=255),
+        nullable=True,
+    )
+    ip_address: Mapped[str | None] = mapped_column(
+        String(length=45),
+        nullable=True,
+    )
+    created_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    user = relationship(
+        argument="UserModel",
+        back_populates="refresh_tokens",
+    )

--- a/app/models/user_points.py
+++ b/app/models/user_points.py
@@ -1,0 +1,38 @@
+"""user points model(entity)"""
+
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, TIMESTAMP, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database.database import Base
+
+
+# pylint:disable=not-callable, too-few-public-methods
+class UserPointsModel(Base):
+    """database user points Model(Entity)"""
+
+    __tablename__ = "user_points"
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id"),
+        primary_key=True,
+        index=True,
+    )
+    balance: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+    # Relationships
+    user = relationship(
+        argument="UserModel",
+        back_populates="user_points",
+    )

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from sqlalchemy import String, TIMESTAMP, func
+from sqlalchemy import ForeignKey, String, TIMESTAMP, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -41,6 +41,12 @@ class UserModel(Base):
         nullable=True,
         default=None,
     )
+    default_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("groups.id"),
+        nullable=True,
+        index=True,
+    )
     created_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
@@ -55,6 +61,11 @@ class UserModel(Base):
     created_groups = relationship(
         argument="GroupModel",
         back_populates="creator",
+        foreign_keys="GroupModel.creator_id",
+    )
+    default_group = relationship(
+        argument="GroupModel",
+        foreign_keys=[default_group_id],
     )
     posts = relationship(
         argument="PostModel",
@@ -69,6 +80,27 @@ class UserModel(Base):
         back_populates="user",
     )
     created_invitation_codes = relationship(
-        argument="InvitationCode",
+        argument="InvitationModel",
         back_populates="creator",
+    )
+    refresh_tokens = relationship(
+        argument="RefreshTokenModel",
+        back_populates="user",
+    )
+    user_points = relationship(
+        argument="UserPointsModel",
+        back_populates="user",
+        uselist=False,
+    )
+    point_transactions = relationship(
+        argument="PointTransactionModel",
+        back_populates="user",
+    )
+    group_memberships = relationship(
+        argument="GroupMembersModel",
+        back_populates="user",
+    )
+    challenge_winners = relationship(
+        argument="ChallengeWinnerModel",
+        back_populates="user",
     )

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -2,8 +2,9 @@
 
 import uuid
 
-from sqlalchemy import Column, String, TIMESTAMP, func
+from sqlalchemy import String, TIMESTAMP, func
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database.database import Base
 
@@ -13,39 +14,61 @@ class UserModel(Base):
     """database users Model(Entity)"""
 
     __tablename__ = "users"
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid.uuid4,
         index=True,
     )
-    username = Column(
+    username: Mapped[str] = mapped_column(
         String(length=30),
         unique=True,
         index=True,
         nullable=False,
     )
-    email = Column(
+    email: Mapped[str] = mapped_column(
         String(length=255),
         unique=True,
         index=True,
         nullable=False,
     )
-    hashed_password = Column(
+    hashed_password: Mapped[str] = mapped_column(
         String(length=255),
         nullable=False,
     )
-    profile_image_url = Column(
+    profile_image_url: Mapped[str | None] = mapped_column(
         String(length=2048),
         nullable=True,
         default=None,
     )
-    created_at = Column(
+    created_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
     )
-    updated_at = Column(
+    updated_at: Mapped[TIMESTAMP] = mapped_column(
         TIMESTAMP(timezone=True),
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+    # Relationships
+    created_groups = relationship(
+        argument="GroupModel",
+        back_populates="creator",
+    )
+    posts = relationship(
+        argument="PostModel",
+        back_populates="user",
+    )
+    likes = relationship(
+        argument="LikeModel",
+        back_populates="user",
+    )
+    comments = relationship(
+        argument="CommentModel",
+        back_populates="user",
+    )
+    created_invitation_codes = relationship(
+        argument="InvitationCode",
+        back_populates="creator",
     )

--- a/scr/init_db.py
+++ b/scr/init_db.py
@@ -3,7 +3,7 @@
 import sys
 from pathlib import Path
 
-# 프로젝트 루트 경로를 sys.path에 추가
+# Add project root path to sys.path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 

--- a/scr/init_db.py
+++ b/scr/init_db.py
@@ -1,0 +1,25 @@
+"""Initial database setup script"""
+
+import sys
+from pathlib import Path
+
+# 프로젝트 루트 경로를 sys.path에 추가
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+# pylint: disable=wrong-import-position
+import app.models as load_models
+from app.config import settings
+from app.database.database import Base, engine
+
+# 설정 로드
+_ = settings
+
+# 모든 모델들을 import하여 SQLAlchemy가 테이블을 인식할 수 있도록 함
+_ = load_models
+
+# 모든 모델들을 import하여 테이블 생성
+print("Creating database tables...")
+Base.metadata.create_all(bind=engine)
+print("Database tables created successfully!")


### PR DESCRIPTION
This pull request introduces a comprehensive set of new SQLAlchemy ORM model classes for the application's core entities, centralizing and standardizing the database schema definitions. It also adds enums for group roles and updates package initialization files to expose the newly created models and enums. The changes lay the groundwork for consistent data modeling and relationships among users, groups, posts, challenges, and related features.

**Database Model Additions:**

* Added new model classes for all major entities, including `UserModel`, `GroupModel`, `GroupMembersModel`, `PostModel`, `CommentModel`, `LikeModel`, `InvitationModel`, `RefreshTokenModel`, `ChallengeModel`, `ChallengeWinnerModel`, `UserPointsModel`, and `PointTransactionModel`. Each model defines its table schema, primary keys, fields, and relationships to other models.

**Enums and Initialization:**

* Introduced a `GroupRole` enum in `app/enums/group_roles.py` to standardize group member roles, and updated the enums package initialization to expose it. 
* Updated the models package initialization in `app/models/__init__.py` to expose all new model classes for easier imports and usage throughout the codebase.

**Relationship and Schema Improvements:**

* Defined explicit relationships between models using SQLAlchemy's `relationship`, enabling ORM-level navigation between related entities (e.g., users and their posts, groups and their members, challenges and their winners).

**General Codebase Consistency:**

* Ensured consistent use of type annotations, naming conventions, and SQLAlchemy constructs across all model files. (all change references above)
* Updated the `users.py` model to use the new `Mapped`, `mapped_column`, and `relationship` patterns for consistency with the new models.

These changes collectively provide a robust and maintainable foundation for all future database interactions and business logic in the application.